### PR TITLE
Re-Merge current version into develop after hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.0.1](https://github.com/YadaYadaAT/Battlesnake/compare/v1.0.0...v1.0.1) (2025-05-09)
+
+
+### Bug Fixes
+
+* restore commitlint config and hook ([faa3f4f](https://github.com/YadaYadaAT/Battlesnake/commit/faa3f4fa52d3cce7deddbe8e933eb8cd9aa887a6))
+
 ## [1.0.0](https://github.com/YadaYadaAT/Battlesnake/compare/v0.0.1...v1.0.0) (2025-05-08)
 
 

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "battlesnake",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "battlesnake",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "ISC",
       "dependencies": {
         "express": "^5.1.0"
       },
       "devDependencies": {
-        "@commitlint/cli": "^19.8.0",
-        "@commitlint/config-conventional": "^19.8.0",
+        "@commitlint/cli": "^19.8.1",
+        "@commitlint/config-conventional": "^19.8.1",
         "@eslint/js": "^9.26.0",
         "conventional-changelog-cli": "^5.0.0",
         "eslint": "^9.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "battlesnake",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "This repository contains the source code and configuration for our Battlesnake game. The project is focused on implementing continuous integration and delivery (CI/CD) pipelines using GitHub Actions, with issue tracking and agile methodologies supported by YouTrack integration.",
   "main": "index.js",
   "scripts": {
@@ -19,10 +19,10 @@
     "express": "^5.1.0"
   },
   "devDependencies": {
-    "@commitlint/cli": "^19.8.0",
-    "@commitlint/config-conventional": "^19.8.0",
-    "conventional-changelog-cli": "^5.0.0",
+    "@commitlint/cli": "^19.8.1",
+    "@commitlint/config-conventional": "^19.8.1",
     "@eslint/js": "^9.26.0",
+    "conventional-changelog-cli": "^5.0.0",
     "eslint": "^9.26.0",
     "eslint-config-prettier": "^10.1.2",
     "eslint-plugin-eslint-comments": "^3.2.0",


### PR DESCRIPTION
Ran a hotfix, re-merging current release into develop with the hotfix included so everyone can sync up to the correct version before working on next sprint